### PR TITLE
Use a different colour for since badge if latest

### DIFF
--- a/quasar_site/src/css/quasar.variables.sass
+++ b/quasar_site/src/css/quasar.variables.sass
@@ -22,3 +22,5 @@ $positive  : #21BA45
 $negative  : #C10015
 $info      : #31CCEC
 $warning   : #F2C037
+
+$new       : $accent

--- a/quasar_site/src/pages/DataType.vue
+++ b/quasar_site/src/pages/DataType.vue
@@ -25,7 +25,7 @@
           <q-item-section>
             <q-item-label>{{signature(member)}}</q-item-label>
             <q-item-label caption>
-              <q-badge v-if="member.since" outline :color="member.since>=version?'warning':'secondary'">{{member.since.toFixed(1)}}
+              <q-badge v-if="member.since" outline :color="member.since===version?'accent':'secondary'">{{member.since.toFixed(1)}}
                 <q-tooltip>Available since {{member.since.toFixed(1)}}</q-tooltip>
               </q-badge>
               {{member.summary}}
@@ -57,7 +57,7 @@ import { DataTypes } from '../RhinoCommonApi'
 
 export default {
   data () {
-    const mostRecent = ViewModel.mostRecentSince().toFixed(1)
+    const mostRecent = ViewModel.mostRecentSince()
     return {
       vm: {},
       title: '',

--- a/quasar_site/src/pages/DataType.vue
+++ b/quasar_site/src/pages/DataType.vue
@@ -25,7 +25,7 @@
           <q-item-section>
             <q-item-label>{{signature(member)}}</q-item-label>
             <q-item-label caption>
-              <q-badge v-if="member.since" outline color="secondary">{{member.since.toFixed(1)}}
+              <q-badge v-if="member.since" outline :color="member.since>=version?'warning':'secondary'">{{member.since.toFixed(1)}}
                 <q-tooltip>Available since {{member.since.toFixed(1)}}</q-tooltip>
               </q-badge>
               {{member.summary}}
@@ -57,13 +57,15 @@ import { DataTypes } from '../RhinoCommonApi'
 
 export default {
   data () {
+    const mostRecent = ViewModel.mostRecentSince().toFixed(1)
     return {
       vm: {},
       title: '',
       namespace: '',
       memberSections: [],
       namespaceItems: null,
-      inheritence: []
+      inheritence: [],
+      version: mostRecent
     }
   },
   created () {


### PR DESCRIPTION
Just an idea to highlight members added in the most recent version of the API