### PR TITLE
WWW-3482 fix missing space between modifiers and declaration

### DIFF
--- a/webapp/src/components/MemberSignature.vue
+++ b/webapp/src/components/MemberSignature.vue
@@ -59,9 +59,10 @@ function enumTitle(token) {
         <div v-if="member.signature" class="text-xl font-medium">Syntax:</div>
         <CodeCard :text="member.signature">
           <span :class="isDisabled ? 'is-disabled' : ''">
+            <!-- Trailing space lives in the expression; Vue's condense strips template whitespace. -->
             <template v-if="member.modifiers && member.modifiers.length"
-              >{{ member.modifiers.join(' ') }}
-            </template>
+              >{{ member.modifiers.join(' ') + ' ' }}</template
+            >
             <template v-for="(chunk, i) in chunks" :key="i">
               <template v-if="chunk.indent"><br /><span class="pl-6" /></template>
               <template v-if="chunk.break"><br /></template>

--- a/webapp/test/render.test.js
+++ b/webapp/test/render.test.js
@@ -11,6 +11,7 @@ import { useApiStore } from '@/stores/api.js'
 import { useSearchStore } from '@/stores/search.js'
 import { useSettingsStore } from '@/stores/settings.js'
 import SearchOverlay from '@/components/SearchOverlay.vue'
+import MemberSignature from '@/components/MemberSignature.vue'
 
 const info = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'src/api_info.json'), 'utf8'))
 const examples = JSON.parse(
@@ -138,6 +139,27 @@ describe('app renders and navigates (happy-dom mount)', () => {
     const links = wrapper.findAll('a')
     expect(links.length).toBeGreaterThan(0)
     expect(wrapper.text().toLowerCase()).toContain('brep')
+  })
+
+  // WWW-3482: modifiers must stay space-separated from the rest of the declaration.
+  it('keeps a space between modifiers and the return type', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({ history: createMemoryHistory('/'), routes })
+    const member = {
+      signature: 'MeshTopologyVertexList TopologyVertices',
+      modifiers: ['public'],
+      property: ['get'],
+      isProperty: true,
+    }
+    const wrapper = mount(MemberSignature, {
+      props: { member, baseUrl: '/' },
+      global: { plugins: [pinia, router] },
+    })
+    await settle()
+    const text = wrapper.text().replace(/\s+/g, ' ')
+    expect(text).toContain('public MeshTopologyVertexList')
+    expect(text).not.toContain('publicMeshTopologyVertexList')
   })
 
   it('dark mode toggles the html class', () => {


### PR DESCRIPTION
Space lived in template whitespace after modifiers interpolation; Vue condense stripped it (last-child). Move space into expression. Add test.

Fixes WWW-3482 