### PR TITLE
Fix dangling "#" on parenless member permalinks

### DIFF
--- a/webapp/src/components/MemberSignature.vue
+++ b/webapp/src/components/MemberSignature.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { parseSignatureChunks, signatureAnchorRef } from '@/utils/signatures.js'
+import { parseSignatureChunks, signatureHash } from '@/utils/signatures.js'
 import { useTypeLinks } from '@/composables/useTypeLinks.js'
 import Icon from './Icon.vue'
 import Badge from './Badge.vue'
@@ -22,7 +22,7 @@ const returnChunks = computed(() => chunks.value.filter((c) => c.isReturn))
 const isDisabled = computed(() => !!(props.member.deprecated || props.member.obsolete))
 
 function anchorTo() {
-  router.push({ hash: '#' + signatureAnchorRef(props.member.signature) })
+  router.push({ hash: signatureHash(props.member.signature) })
 }
 function isInternal(link) {
   return link && !link.toLowerCase().startsWith('http')

--- a/webapp/src/pages/DataTypePage.vue
+++ b/webapp/src/pages/DataTypePage.vue
@@ -11,7 +11,7 @@ import {
 import { useApiStore } from '@/stores/api'
 import { useVersionFilter } from '@/composables/useVersionFilter'
 import { useDocumentMeta } from '@/composables/useDocumentMeta'
-import { memberName, signatureAnchorRef } from '@/utils/signatures'
+import { memberName, signatureHash } from '@/utils/signatures'
 import MemberSignature from '@/components/MemberSignature.vue'
 import Breadcrumbs from '@/components/Breadcrumbs.vue'
 import Badge from '@/components/Badge.vue'
@@ -133,7 +133,7 @@ function memberClass(member) {
 }
 function memberTo(section, member) {
   if (section.type === 'values') return undefined
-  return props.baseUrl + member.path + '#' + signatureAnchorRef(member.signature)
+  return props.baseUrl + member.path + signatureHash(member.signature)
 }
 function isInherited(member) {
   return member.parent !== namespace.value + '.' + name.value

--- a/webapp/src/utils/search.js
+++ b/webapp/src/utils/search.js
@@ -1,5 +1,5 @@
 // Search index construction. Pure — ported from ViewModel.js#getSearchList.
-import { signatureAnchorRef, memberName } from './signatures.js'
+import { signatureHash, memberName } from './signatures.js'
 
 // Fuse.js options. NOTE: the old code had `{name:'member',weight:10}.name`, which
 // silently collapsed to the string "member" (default weight 1). Fixed here so the
@@ -37,7 +37,7 @@ export function buildSearchList(apiInfo) {
         node = { typename, member: chunks[chunks.length - 1] }
         if (items[items.length - 1].member === node.member) return
         node.type = 'property'
-        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}#${signatureAnchorRef(prop.signature)}`
+        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}${signatureHash(prop.signature)}`
         node.since = entry.since
         node.keywords = dataTypeUrl.replaceAll('.', ' ') + ' ' + node.member.toLowerCase()
         if (prop.summary) node.summary = prop.summary
@@ -50,7 +50,7 @@ export function buildSearchList(apiInfo) {
         chunks = chunks[0].split(' ')
         node = { typename, member: chunks[chunks.length - 1] }
         node.type = 'method'
-        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}#${signatureAnchorRef(method.signature)}`
+        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}${signatureHash(method.signature)}`
         node.since = method.since
         node.keywords = dataTypeUrl.replaceAll('.', ' ') + ' ' + node.member.toLowerCase()
         if (method.summary) node.summary = method.summary
@@ -63,7 +63,7 @@ export function buildSearchList(apiInfo) {
         node = { typename, member: chunks[chunks.length - 1] }
         if (items[items.length - 1].member === node.member) return
         node.type = 'event'
-        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}#${signatureAnchorRef(event.signature)}`
+        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}${signatureHash(event.signature)}`
         node.since = event.since
         node.keywords = dataTypeUrl.replaceAll('.', ' ') + ' ' + node.member.toLowerCase()
         if (event.summary) node.summary = event.summary
@@ -76,7 +76,7 @@ export function buildSearchList(apiInfo) {
         node = { typename, member: chunks[chunks.length - 1] }
         if (items[items.length - 1].member === node.member) return
         node.type = 'operator'
-        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}#${signatureAnchorRef(operator.signature)}`
+        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}${signatureHash(operator.signature)}`
         node.since = operator.since
         node.keywords = dataTypeUrl.replaceAll('.', ' ') + ' ' + node.member.toLowerCase()
         if (operator.summary) node.summary = operator.summary
@@ -91,7 +91,7 @@ export function buildSearchList(apiInfo) {
         node = { typename, member: memberName(field, 'fields') }
         if (items[items.length - 1].member === node.member) return
         node.type = 'field'
-        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}#${signatureAnchorRef(field.signature)}`
+        node.url = `${dataTypeUrl}/${node.member.toLowerCase()}${signatureHash(field.signature)}`
         node.since = field.since
         node.keywords = dataTypeUrl.replaceAll('.', ' ') + ' ' + node.member.toLowerCase()
         if (field.summary) node.summary = field.summary

--- a/webapp/src/utils/signatures.js
+++ b/webapp/src/utils/signatures.js
@@ -49,6 +49,14 @@ export function signatureAnchorRef(signature) {
   return shortSignature(signature)[1].toLocaleLowerCase().replace(/\s/g, '')
 }
 
+// The "#anchor" URL suffix for a member, or '' when the signature has no overload
+// anchor (parenless members: properties, fields, events). Prevents a dangling '#'
+// on clean permalinks (WWW-3482).
+export function signatureHash(signature) {
+  const ref = signatureAnchorRef(signature)
+  return ref ? '#' + ref : ''
+}
+
 // Breaks a member signature into renderable chunks (return type, params, links).
 // `links` supplies { typeUrl, typeFromToken } (from useTypeLinks) to keep this pure.
 export function parseSignatureChunks(member, links) {

--- a/webapp/src/utils/tree.js
+++ b/webapp/src/utils/tree.js
@@ -1,6 +1,6 @@
 // Navigation tree construction. Pure — ported from ViewModel.js (getTree/childTree/lazyChildForPath).
 import { itemPath } from './paths.js'
-import { memberName, shortSignature, signatureAnchorRef } from './signatures.js'
+import { memberName, shortSignature, signatureHash } from './signatures.js'
 import { collectMembers } from './members.js'
 
 // Builds the namespace -> type tree (types start with empty, lazily-loaded children)
@@ -77,7 +77,7 @@ export function buildMemberGroups(type, typeMap) {
             overloads.length > 1
               ? overloads.map((o) => ({
                   label: shortSignature(memberName(o, lc))[1],
-                  path: `${o.path}#${signatureAnchorRef(o.signature)}`,
+                  path: `${o.path}${signatureHash(o.signature)}`,
                   since: o.since,
                 }))
               : [],

--- a/webapp/test/integration.test.js
+++ b/webapp/test/integration.test.js
@@ -80,6 +80,17 @@ describe('real-data pipeline', () => {
     expect(fields.some((f) => f.member === 'true')).toBe(false)
     const inc = fields.find((f) => f.member === 'IncludeNormals')
     expect(inc).toBeTruthy()
-    expect(inc.url).toContain('/includenormals#')
+    expect(inc.url).toMatch(/\/includenormals$/)
+  })
+
+  it('parenless member URLs have no dangling "#" (WWW-3482)', () => {
+    const list = buildSearchList(info)
+    // No search URL should end with a bare '#' (the reported search-result bug).
+    expect(list.filter((i) => i.url.endsWith('#'))).toEqual([])
+    // Properties/fields/events get a clean, anchorless permalink...
+    const prop = list.find((i) => i.type === 'property')
+    expect(prop.url).not.toContain('#')
+    // ...while overloadable members (methods) keep their overload anchor.
+    expect(list.some((i) => i.type === 'method' && i.url.includes('#'))).toBe(true)
   })
 })

--- a/webapp/test/render.test.js
+++ b/webapp/test/render.test.js
@@ -11,6 +11,7 @@ import { useApiStore } from '@/stores/api.js'
 import { useSearchStore } from '@/stores/search.js'
 import { useSettingsStore } from '@/stores/settings.js'
 import SearchOverlay from '@/components/SearchOverlay.vue'
+import MemberSignature from '@/components/MemberSignature.vue'
 
 const info = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'src/api_info.json'), 'utf8'))
 const examples = JSON.parse(
@@ -138,6 +139,35 @@ describe('app renders and navigates (happy-dom mount)', () => {
     const links = wrapper.findAll('a')
     expect(links.length).toBeGreaterThan(0)
     expect(wrapper.text().toLowerCase()).toContain('brep')
+    // WWW-3482: clicking a result must not land on a URL ending with a bare '#'.
+    for (const a of links) {
+      expect((a.attributes('href') || '').endsWith('#')).toBe(false)
+    }
+  })
+
+  // WWW-3482: the "link to this member" button on a parenless member (property/field/
+  // event) must produce a clean, hashless permalink.
+  it('permalink button yields a hashless URL for a parenless member', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({ history: createMemoryHistory('/'), routes })
+    const member = {
+      signature: 'MeshTopologyVertexList TopologyVertices',
+      modifiers: ['public'],
+      property: ['get'],
+      isProperty: true,
+    }
+    router.push('/rhino.geometry.mesh/topologyvertices')
+    await router.isReady()
+    const wrapper = mount(MemberSignature, {
+      props: { member, baseUrl: '/' },
+      global: { plugins: [pinia, router] },
+    })
+    await settle()
+    await wrapper.find('button[aria-label="Link to this member"]').trigger('click')
+    await settle()
+    expect(router.currentRoute.value.hash).toBe('')
+    expect(router.currentRoute.value.fullPath.endsWith('#')).toBe(false)
   })
 
   it('dark mode toggles the html class', () => {

--- a/webapp/test/utils.test.js
+++ b/webapp/test/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { sinceIsGreater, mostRecentSince, majorVersionList } from '@/utils/version.js'
-import { memberName, shortSignature, signatureAnchorRef } from '@/utils/signatures.js'
+import { memberName, shortSignature, signatureAnchorRef, signatureHash } from '@/utils/signatures.js'
 import { itemPath, memberUrl } from '@/utils/paths.js'
 import { refToPath } from '@/utils/sandcastle.js'
 import { buildTypeMap, getInheritance } from '@/utils/typemap.js'
@@ -55,6 +55,10 @@ describe('signatures', () => {
     expect(signatureAnchorRef('Foo(System.Double x, Rhino.Geometry.Point3d p)')).toBe(
       '(double,point3d)'
     )
+  })
+  it('signatureHash prefixes "#" for overloads, empty for parenless (WWW-3482)', () => {
+    expect(signatureHash('Foo(System.Double x)')).toBe('#(double)')
+    expect(signatureHash('MeshTopologyVertexList TopologyVertices')).toBe('')
   })
 })
 


### PR DESCRIPTION
signatureAnchorRef() returns '' for parenless members (properties, fields, events) -> URLs built as path#'' left a trailing '#', seen when clicking a search result. Add signatureHash() (returns '#anchor' or '') and use at every URL site: search index, type-page links, nav-tree overloads, permalink button. Update/adds tests.