### PR TITLE
WWW-3489 show BCL-inherited members on API type pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ $ api_docify.exe --name="RhinoCommon" "%RHINO4SRC%/rhinocommon/dotnet" "src/modu
 4. Run `CMD+Shift+P > Run Task > docify build` (or run the generator) to produce the JSON
 5. Run `cd webapp && yarn dev` to start the site
 
+## BCL base types
+
+Classes that derive from a .NET Base Class Library type (e.g. `RuntimeDocumentDataTable : Dictionary<object, object>`) inherit members the syntactic parser can't see. `build` also emits `bcl_api.json` next to `api_info.json`: it reflects the .NET reference assemblies (and their XML docs) via Roslyn to produce authoritative metadata for those base types, which the web app renders as inherited members linking to Microsoft Learn. It is generated, not hand-written — regenerate from committed data (no Rhino source needed) with:
+
+```shell
+$ dotnet run --project src -- bcl webapp/src/api_info.json webapp/src/bcl_api.json
+```
+
 ## Troubleshooting
 
 Some namespaces may need `methodgen` to be run on the source first before documentation can be extracted. You can do this by building Rhino from source.

--- a/src/Parse/BclMetadata.cs
+++ b/src/Parse/BclMetadata.cs
@@ -1,0 +1,523 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Newtonsoft.Json;
+
+namespace Docify.Parse
+{
+    /// <summary>
+    /// Generates authoritative metadata for the .NET Base Class Library (BCL) base
+    /// types that RhinoCommon classes derive from (WWW-3489).
+    ///
+    /// The main generator is purely syntactic, so a class deriving from a BCL type
+    /// (e.g. RuntimeDocumentDataTable : Dictionary&lt;object,object&gt;) exposes none
+    /// of its inherited API. Rather than hand-curating that, this reflects the real
+    /// .NET reference assemblies (with their XML docs) via Roslyn and emits the
+    /// members + Microsoft Learn links the web app renders as inherited members.
+    ///
+    /// The output (bcl_api.json) is keyed by the same normalized base token the web
+    /// app computes in getInheritance(): the last dotted segment with generic args
+    /// collapsed to "&lt;T&gt;" (e.g. "System.Collections.Generic.Dictionary&lt;object,
+    /// object&gt;" -&gt; "Dictionary&lt;T&gt;").
+    /// </summary>
+    static class BclMetadata
+    {
+        const string MsLearn = "https://learn.microsoft.com/en-us/dotnet/api/";
+
+        // doc-comment id (e.g. "M:System...ContainsKey(`0)") -> summary text, parsed
+        // from the reference assemblies' XML doc files.
+        static Dictionary<string, string> _summaries = new(StringComparer.Ordinal);
+
+        static readonly SymbolDisplayFormat ShortType = new SymbolDisplayFormat(
+            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        // ---- public entry points -------------------------------------------------
+
+        /// <summary>
+        /// Standalone command: read base types from an existing api_info.json and write
+        /// bcl_api.json next to it (or to <paramref name="outputPath"/>). Lets the BCL
+        /// data be regenerated from committed data without a full Rhino source build.
+        /// </summary>
+        public static void RunStandalone(string apiInfoPath, string outputPath)
+        {
+            if (!GenerateFromApiInfo(apiInfoPath, outputPath))
+                Environment.Exit(1);
+        }
+
+        /// <summary>
+        /// Read base types from an api_info.json and write bcl_api.json. Returns false
+        /// on failure (logged) rather than throwing/exiting, so callers in the middle of
+        /// a build aren't disrupted. Called both by the standalone command and at the
+        /// end of a full build.
+        /// </summary>
+        public static bool GenerateFromApiInfo(string apiInfoPath, string outputPath)
+        {
+            if (!File.Exists(apiInfoPath))
+            {
+                Console.Error.WriteLine($"BCL metadata: api_info not found: {apiInfoPath}");
+                return false;
+            }
+            List<ApiType> types;
+            try
+            {
+                string json = File.ReadAllText(apiInfoPath);
+                // The file may be a .js module (var RhinoCommonApi = [ ... ]) or plain JSON.
+                int start = json.IndexOf('[');
+                int end = json.LastIndexOf(']');
+                if (start < 0 || end < start)
+                {
+                    Console.Error.WriteLine("BCL metadata: could not find JSON array in api_info file");
+                    return false;
+                }
+                types = JsonConvert.DeserializeObject<List<ApiType>>(json.Substring(start, end - start + 1));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"BCL metadata: failed to read {apiInfoPath}: {ex.Message}");
+                return false;
+            }
+
+            var known = new HashSet<string>(
+                types.Where(t => t.Name != null).Select(t => t.Name), StringComparer.Ordinal);
+            var baseTokens = types.Where(t => !string.IsNullOrEmpty(t.Baseclass)).Select(t => t.Baseclass);
+
+            return Write(baseTokens, known, outputPath);
+        }
+
+        /// <summary>
+        /// Resolve every needed BCL base token to a reference-assembly symbol and write
+        /// the metadata map to <paramref name="outputPath"/>. Never throws out to the
+        /// caller — a failure here must not break the main documentation build.
+        /// </summary>
+        public static bool Write(IEnumerable<string> baseTokens, ISet<string> knownRhinoTypeNames, string outputPath)
+        {
+            try
+            {
+                // Keep only bases the web app can't already resolve within RhinoCommon,
+                // keyed by the web app's normalized token so we emit one entry per base.
+                var tokensByKey = new Dictionary<string, string>(StringComparer.Ordinal);
+                foreach (var raw in baseTokens)
+                {
+                    string key = NormalizeKey(raw);
+                    string simple = SimpleName(raw);
+                    if (key == "EventArgs" || knownRhinoTypeNames.Contains(key) || knownRhinoTypeNames.Contains(simple))
+                        continue;
+                    if (!tokensByKey.ContainsKey(key))
+                        tokensByKey[key] = raw;
+                }
+                if (tokensByKey.Count == 0)
+                {
+                    Console.WriteLine("BCL metadata: no external base types found");
+                    return true;
+                }
+
+                var index = BuildTypeIndex(out string refDir);
+                if (index == null)
+                {
+                    Console.Error.WriteLine("BCL metadata: could not locate .NET reference assemblies; skipping");
+                    return false;
+                }
+                Console.WriteLine($"BCL metadata: using reference assemblies at {refDir}");
+
+                var result = new SortedDictionary<string, object>(StringComparer.Ordinal);
+                foreach (var kv in tokensByKey.OrderBy(k => k.Key, StringComparer.Ordinal))
+                {
+                    var symbol = Resolve(index, kv.Value);
+                    if (symbol == null)
+                    {
+                        Console.WriteLine($"BCL metadata: unresolved base '{kv.Value}' (key {kv.Key})");
+                        continue;
+                    }
+                    result[kv.Key] = BuildType(symbol);
+                    Console.WriteLine($"BCL metadata: {kv.Key} -> {symbol.ToDisplayString()}");
+                }
+
+                var settings = new JsonSerializerSettings { Formatting = Formatting.Indented };
+                File.WriteAllText(outputPath, JsonConvert.SerializeObject(result, settings));
+                Console.WriteLine($"BCL metadata: wrote {result.Count} type(s) to {outputPath}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"BCL metadata generation failed (non-fatal): {ex.Message}");
+                return false;
+            }
+        }
+
+        // ---- token normalization (mirrors the web app's getInheritance) ----------
+
+        // Last dotted segment with generic args collapsed to "<T>".
+        static string NormalizeKey(string baseToken)
+        {
+            string b = SimpleName(baseToken);
+            if (baseToken.IndexOf('<') > 0) b += "<T>";
+            return b;
+        }
+
+        // Last dotted segment, generic args stripped (e.g. "System.IO.IOException" -> "IOException").
+        static string SimpleName(string baseToken)
+        {
+            int lt = baseToken.IndexOf('<');
+            string head = lt > 0 ? baseToken.Substring(0, lt) : baseToken;
+            int dot = head.LastIndexOf('.');
+            return dot >= 0 ? head.Substring(dot + 1) : head;
+        }
+
+        static int Arity(string baseToken)
+        {
+            int lt = baseToken.IndexOf('<');
+            if (lt < 0) return 0;
+            int depth = 0, count = 1;
+            for (int i = lt; i < baseToken.Length; i++)
+            {
+                char c = baseToken[i];
+                if (c == '<') depth++;
+                else if (c == '>') { depth--; if (depth == 0) break; }
+                else if (c == ',' && depth == 1) count++;
+            }
+            return count;
+        }
+
+        // ---- reference-assembly resolution ---------------------------------------
+
+        // Index of top-level public reference types, by full metadata name and by
+        // simple metadata name (System-namespace preferred on collisions).
+        class TypeIndex
+        {
+            public Dictionary<string, INamedTypeSymbol> ByFull = new(StringComparer.Ordinal);
+            public Dictionary<string, INamedTypeSymbol> BySimple = new(StringComparer.Ordinal);
+        }
+
+        static TypeIndex BuildTypeIndex(out string refDir)
+        {
+            refDir = FindReferenceAssemblyDir();
+            if (refDir == null) return null;
+
+            var references = new List<MetadataReference>();
+            foreach (var dll in Directory.GetFiles(refDir, "*.dll"))
+            {
+                references.Add(MetadataReference.CreateFromFile(dll));
+                LoadSummaries(Path.ChangeExtension(dll, ".xml"));
+            }
+
+            var compilation = CSharpCompilation.Create("bcl", references: references);
+            var index = new TypeIndex();
+            foreach (var type in AllTopLevelTypes(compilation.GlobalNamespace))
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public) continue;
+                string ns = type.ContainingNamespace?.ToDisplayString() ?? "";
+                string full = string.IsNullOrEmpty(ns) ? type.MetadataName : ns + "." + type.MetadataName;
+                if (!index.ByFull.ContainsKey(full)) index.ByFull[full] = type;
+                if (!index.BySimple.TryGetValue(type.MetadataName, out var existing) || Prefer(type, existing))
+                    index.BySimple[type.MetadataName] = type;
+            }
+            return index;
+        }
+
+        // Prefer System-rooted, then shorter namespaces, then ordinal — enough to pick
+        // the canonical type when a simple name collides across assemblies.
+        static bool Prefer(INamedTypeSymbol candidate, INamedTypeSymbol current)
+        {
+            string a = candidate.ContainingNamespace?.ToDisplayString() ?? "";
+            string b = current.ContainingNamespace?.ToDisplayString() ?? "";
+            bool aSys = a == "System" || a.StartsWith("System.");
+            bool bSys = b == "System" || b.StartsWith("System.");
+            if (aSys != bSys) return aSys;
+            int da = a.Count(c => c == '.'), db = b.Count(c => c == '.');
+            if (da != db) return da < db;
+            return string.CompareOrdinal(a, b) < 0;
+        }
+
+        static INamedTypeSymbol Resolve(TypeIndex index, string baseToken)
+        {
+            int arity = Arity(baseToken);
+            string simple = SimpleName(baseToken) + (arity > 0 ? "`" + arity : "");
+
+            int lt = baseToken.IndexOf('<');
+            string head = lt > 0 ? baseToken.Substring(0, lt) : baseToken;
+            if (head.Contains('.'))
+            {
+                string full = head + (arity > 0 ? "`" + arity : "");
+                if (index.ByFull.TryGetValue(full, out var byFull)) return byFull;
+            }
+            return index.BySimple.TryGetValue(simple, out var bySimple) ? bySimple : null;
+        }
+
+        static IEnumerable<INamedTypeSymbol> AllTopLevelTypes(INamespaceSymbol ns)
+        {
+            foreach (var t in ns.GetTypeMembers()) yield return t;
+            foreach (var child in ns.GetNamespaceMembers())
+                foreach (var t in AllTopLevelTypes(child))
+                    yield return t;
+        }
+
+        static string FindReferenceAssemblyDir()
+        {
+            // dotnet root: env override, else derived from the running runtime dir.
+            var roots = new List<string>();
+            string envRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            if (!string.IsNullOrEmpty(envRoot)) roots.Add(envRoot);
+            string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            // runtimeDir ~ {root}/shared/Microsoft.NETCore.App/{ver}; go up 3.
+            if (!string.IsNullOrEmpty(runtimeDir))
+            {
+                var up = Directory.GetParent(runtimeDir)?.Parent?.Parent?.FullName;
+                if (up != null) roots.Add(up);
+            }
+            roots.Add("/usr/local/share/dotnet");
+            roots.Add(@"C:\Program Files\dotnet");
+
+            var major = Environment.Version.Major; // 8 for net8.0
+            foreach (var root in roots.Where(r => !string.IsNullOrEmpty(r) && Directory.Exists(r)))
+            {
+                string packRoot = Path.Combine(root, "packs", "Microsoft.NETCore.App.Ref");
+                if (!Directory.Exists(packRoot)) continue;
+                var best = Directory.GetDirectories(packRoot)
+                    .Select(d => new { dir = d, ver = ParseVersion(Path.GetFileName(d)) })
+                    .Where(x => x.ver != null && x.ver.Major == major)
+                    .OrderByDescending(x => x.ver)
+                    .FirstOrDefault();
+                if (best == null) continue;
+                var tfmDir = Directory.GetDirectories(Path.Combine(best.dir, "ref"))
+                    .OrderByDescending(d => d)
+                    .FirstOrDefault();
+                if (tfmDir != null) return tfmDir;
+            }
+            return null;
+        }
+
+        static Version ParseVersion(string s)
+        {
+            int dash = s.IndexOf('-'); // strip pre-release suffix
+            if (dash > 0) s = s.Substring(0, dash);
+            return Version.TryParse(s, out var v) ? v : null;
+        }
+
+        // ---- member extraction ---------------------------------------------------
+
+        static object BuildType(INamedTypeSymbol symbol)
+        {
+            var properties = new List<object>();
+            var methods = new List<object>();
+            var fields = new List<object>();
+            var events = new List<object>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            // Walk the type and its bases (stop before System.Object, whose members
+            // — ToString/Equals/GetHashCode/GetType — are noise on every type).
+            for (var t = symbol; t != null && t.SpecialType != SpecialType.System_Object; t = t.BaseType)
+            {
+                foreach (var m in t.GetMembers())
+                {
+                    if (m.DeclaredAccessibility != Accessibility.Public &&
+                        m.DeclaredAccessibility != Accessibility.Protected)
+                        continue;
+                    // Static members aren't inherited in the documentation sense (they're
+                    // accessed via the declaring type) and are mostly noise here.
+                    if (m.IsStatic || m.IsImplicitlyDeclared || IsObsolete(m)) continue;
+
+                    switch (m)
+                    {
+                        case IPropertySymbol p:
+                            AddUnique(seen, "P", MemberSignature(p), () => properties.Add(PropertyJson(p)));
+                            break;
+                        case IMethodSymbol me when me.MethodKind == MethodKind.Ordinary:
+                            AddUnique(seen, "M", MemberSignature(me), () => methods.Add(MethodJson(me)));
+                            break;
+                        case IFieldSymbol f when !f.IsConst:
+                            AddUnique(seen, "F", MemberSignature(f), () => fields.Add(FieldJson(f)));
+                            break;
+                        case IEventSymbol e:
+                            AddUnique(seen, "E", MemberSignature(e), () => events.Add(EventJson(e)));
+                            break;
+                    }
+                }
+            }
+
+            var node = new Dictionary<string, object>
+            {
+                ["namespace"] = symbol.ContainingNamespace?.ToDisplayString() ?? "",
+                ["name"] = symbol.ToDisplayString(ShortType),
+                ["dataType"] = "class",
+                ["docsUrl"] = DocUrl(symbol),
+            };
+            if (properties.Count > 0) node["properties"] = Sorted(properties);
+            if (methods.Count > 0) node["methods"] = Sorted(methods);
+            if (fields.Count > 0) node["fields"] = Sorted(fields);
+            if (events.Count > 0) node["events"] = Sorted(events);
+            return node;
+        }
+
+        static List<object> Sorted(List<object> members) =>
+            members.OrderBy(m => (string)((Dictionary<string, object>)m)["signature"], StringComparer.Ordinal).ToList();
+
+        static void AddUnique(HashSet<string> seen, string kind, string sig, Action add)
+        {
+            if (seen.Add(kind + ":" + sig)) add();
+        }
+
+        static Dictionary<string, object> PropertyJson(IPropertySymbol p)
+        {
+            var d = BaseMember(p, MemberSignature(p));
+            if (!p.IsIndexer)
+            {
+                var access = new List<string>();
+                if (p.GetMethod != null && p.GetMethod.DeclaredAccessibility == Accessibility.Public) access.Add("get");
+                if (p.SetMethod != null && p.SetMethod.DeclaredAccessibility == Accessibility.Public) access.Add("set");
+                if (access.Count > 0) d["property"] = access;
+            }
+            return d;
+        }
+
+        static Dictionary<string, object> MethodJson(IMethodSymbol m) => BaseMember(m, MemberSignature(m));
+        static Dictionary<string, object> FieldJson(IFieldSymbol f) => BaseMember(f, MemberSignature(f));
+        static Dictionary<string, object> EventJson(IEventSymbol e) => BaseMember(e, MemberSignature(e));
+
+        static Dictionary<string, object> BaseMember(ISymbol s, string signature)
+        {
+            var modifiers = new List<string> { s.DeclaredAccessibility == Accessibility.Protected ? "protected" : "public" };
+            if (s.IsStatic) modifiers.Add("static");
+            var d = new Dictionary<string, object>
+            {
+                ["signature"] = signature,
+                ["modifiers"] = modifiers,
+                ["protected"] = s.DeclaredAccessibility == Accessibility.Protected,
+                ["virtual"] = s.IsVirtual || s.IsOverride || s.IsAbstract,
+                ["docsUrl"] = DocUrl(s),
+            };
+            string summary = DocSummary(s.GetDocumentationCommentId());
+            if (!string.IsNullOrWhiteSpace(summary)) d["summary"] = summary;
+            return d;
+        }
+
+        static string MemberSignature(ISymbol s)
+        {
+            switch (s)
+            {
+                case IPropertySymbol p when p.IsIndexer:
+                    return $"{p.Type.ToDisplayString(ShortType)} this[{Parameters(p.Parameters)}]";
+                case IPropertySymbol p:
+                    return $"{p.Type.ToDisplayString(ShortType)} {p.Name}";
+                case IMethodSymbol m:
+                    return $"{m.ReturnType.ToDisplayString(ShortType)} {m.Name}({Parameters(m.Parameters)})";
+                case IFieldSymbol f:
+                    return $"{f.Type.ToDisplayString(ShortType)} {f.Name}";
+                case IEventSymbol e:
+                    return $"{e.Type.ToDisplayString(ShortType)} {e.Name}";
+                default:
+                    return s.Name;
+            }
+        }
+
+        static string Parameters(IEnumerable<IParameterSymbol> ps)
+        {
+            return string.Join(", ", ps.Select(p =>
+            {
+                string prefix = p.RefKind switch
+                {
+                    RefKind.Out => "out ",
+                    RefKind.Ref => "ref ",
+                    RefKind.In => "in ",
+                    _ => ""
+                };
+                if (p.IsParams) prefix = "params ";
+                return $"{prefix}{p.Type.ToDisplayString(ShortType)} {p.Name}";
+            }));
+        }
+
+        static bool IsObsolete(ISymbol s) =>
+            s.GetAttributes().Any(a => a.AttributeClass?.Name == "ObsoleteAttribute");
+
+        // ---- Microsoft Learn URL + XML summary -----------------------------------
+
+        // Doc-comment id (e.g. "M:System...Dictionary`2.ContainsKey(`0)") -> MS Learn slug.
+        static string DocUrl(ISymbol s)
+        {
+            string id = s.GetDocumentationCommentId();
+            if (string.IsNullOrEmpty(id)) return MsLearn;
+            int colon = id.IndexOf(':');
+            if (colon >= 0) id = id.Substring(colon + 1);
+            int paren = id.IndexOf('(');
+            if (paren >= 0) id = id.Substring(0, paren);
+            id = Regex.Replace(id, "``\\d+", "");        // method type-parameter count
+            id = Regex.Replace(id, "`(\\d+)", "-$1");    // type arity -> -N
+            return MsLearn + id.ToLowerInvariant();
+        }
+
+        static string DocSummary(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return null;
+            return _summaries.TryGetValue(id, out var s) ? s : null;
+        }
+
+        // Parse a reference assembly's XML doc file into the doc-id -> summary map.
+        static void LoadSummaries(string xmlPath)
+        {
+            if (!File.Exists(xmlPath)) return;
+            try
+            {
+                var doc = XDocument.Load(xmlPath);
+                foreach (var member in doc.Descendants("member"))
+                {
+                    string name = member.Attribute("name")?.Value;
+                    var summary = member.Element("summary");
+                    if (name == null || summary == null || _summaries.ContainsKey(name)) continue;
+                    var sb = new StringBuilder();
+                    RenderXml(summary, sb);
+                    string text = Regex.Replace(sb.ToString(), "\\s+", " ").Trim();
+                    if (text.Length > 0) _summaries[name] = text;
+                }
+            }
+            catch
+            {
+                // ignore malformed doc files
+            }
+        }
+
+        static void RenderXml(XElement el, StringBuilder sb)
+        {
+            foreach (var node in el.Nodes())
+            {
+                if (node is XText text)
+                {
+                    sb.Append(text.Value);
+                }
+                else if (node is XElement child)
+                {
+                    string cref = child.Attribute("cref")?.Value;
+                    string langword = child.Attribute("langword")?.Value;
+                    string name = child.Attribute("name")?.Value;
+                    if (cref != null)
+                    {
+                        int paren = cref.IndexOf('(');
+                        if (paren >= 0) cref = cref.Substring(0, paren); // drop method params
+                        int dot = cref.LastIndexOf('.');
+                        string seg = dot >= 0 ? cref.Substring(dot + 1) : cref;
+                        sb.Append(Regex.Replace(seg, "`+\\d+", "")); // drop generic arity backticks
+                    }
+                    else if (langword != null) sb.Append(langword);
+                    else if (name != null) sb.Append(name);
+                    else RenderXml(child, sb);
+                }
+            }
+        }
+
+        // Minimal shape for reading api_info.json in the standalone path.
+        class ApiType
+        {
+            [JsonProperty("name")] public string Name { get; set; }
+            [JsonProperty("baseclass")] public string Baseclass { get; set; }
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,6 +20,7 @@ namespace Docify
     Usage:
       {name} init [<project_name>] [--target=<out_dir>] [--source=<source_dir>] [--examples=<examples_dir>] [--force]
       {name} build
+      {name} bcl <api_info> <output>
 
     Options:
       -h --help                 Show this help
@@ -63,6 +64,14 @@ namespace Docify
                 // build the docs data file
                 Console.WriteLine($"Building docs:\n{source} => {outputDir}");
                 Docify(source, examplesDir, outputDir);
+            }
+            else if (inputs["bcl"].IsTrue)
+            {
+                // Generate BCL base-type metadata from the .NET reference assemblies
+                // (WWW-3489) without needing a full source build.
+                Parse.BclMetadata.RunStandalone(
+                    inputs["<api_info>"].Value.ToString(),
+                    inputs["<output>"].Value.ToString());
             }
         }
 
@@ -177,6 +186,9 @@ namespace Docify
             //MarkdownBuilder.WriteTypes(allTypes, markdownOutput);
             string outputDataFile = Path.Combine(outputDir, ProgramConfigs.OutputDataFile);
             JsonBuilder.Write(allNamespaces, publicTypesByNamespace, allDelegates, outputDataFile);
+            // Emit metadata for BCL base types the web app can't resolve on its own
+            // (WWW-3489), derived from the data just written. Non-fatal on failure.
+            BclMetadata.GenerateFromApiInfo(outputDataFile, Path.Combine(outputDir, "bcl_api.json"));
             // write the samples if sample base dir is provided
             if (!string.IsNullOrWhiteSpace(examplesDir) && Directory.Exists(examplesDir))
             {

--- a/webapp/src/bcl_api.json
+++ b/webapp/src/bcl_api.json
@@ -1,0 +1,2327 @@
+{
+  "Attribute": {
+    "namespace": "System",
+    "name": "Attribute",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.attribute",
+    "properties": [
+      {
+        "signature": "object TypeId",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.attribute.typeid",
+        "summary": "When implemented in a derived class, gets a unique identifier for this Attribute.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "bool Equals(object obj)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.attribute.equals",
+        "summary": "Returns a value that indicates whether this instance is equal to a specified object."
+      },
+      {
+        "signature": "bool IsDefaultAttribute()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.attribute.isdefaultattribute",
+        "summary": "When overridden in a derived class, indicates whether the value of this instance is the default value for the derived class."
+      },
+      {
+        "signature": "bool Match(object obj)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.attribute.match",
+        "summary": "When overridden in a derived class, returns a value that indicates whether this instance equals a specified object."
+      },
+      {
+        "signature": "int GetHashCode()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.attribute.gethashcode",
+        "summary": "Returns the hash code for this instance."
+      }
+    ]
+  },
+  "CancelEventArgs": {
+    "namespace": "System.ComponentModel",
+    "name": "CancelEventArgs",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.canceleventargs",
+    "properties": [
+      {
+        "signature": "bool Cancel",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.canceleventargs.cancel",
+        "summary": "Gets or sets a value indicating whether the event should be canceled.",
+        "property": [
+          "get",
+          "set"
+        ]
+      }
+    ]
+  },
+  "Dictionary<T>": {
+    "namespace": "System.Collections.Generic",
+    "name": "Dictionary<TKey, TValue>",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2",
+    "properties": [
+      {
+        "signature": "IEqualityComparer<TKey> Comparer",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.comparer",
+        "summary": "Gets the IEqualityComparer that is used to determine equality of keys for the dictionary.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "KeyCollection Keys",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.keys",
+        "summary": "Gets a collection containing the keys in the Dictionary.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "TValue this[TKey key]",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.item",
+        "summary": "Gets or sets the value associated with the specified key."
+      },
+      {
+        "signature": "ValueCollection Values",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.values",
+        "summary": "Gets a collection containing the values in the Dictionary.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int Count",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.count",
+        "summary": "Gets the number of key/value pairs contained in the Dictionary.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "Enumerator GetEnumerator()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.getenumerator",
+        "summary": "Returns an enumerator that iterates through the Dictionary."
+      },
+      {
+        "signature": "bool ContainsKey(TKey key)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.containskey",
+        "summary": "Determines whether the Dictionary contains the specified key."
+      },
+      {
+        "signature": "bool ContainsValue(TValue value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.containsvalue",
+        "summary": "Determines whether the Dictionary contains a specific value."
+      },
+      {
+        "signature": "bool Remove(TKey key)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.remove",
+        "summary": "Removes the value with the specified key from the Dictionary."
+      },
+      {
+        "signature": "bool Remove(TKey key, out TValue value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.remove",
+        "summary": "Removes the value with the specified key from the Dictionary, and copies the element to the value parameter."
+      },
+      {
+        "signature": "bool TryAdd(TKey key, TValue value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.tryadd",
+        "summary": "Attempts to add the specified key and value to the dictionary."
+      },
+      {
+        "signature": "bool TryGetValue(TKey key, out TValue value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trygetvalue",
+        "summary": "Gets the value associated with the specified key."
+      },
+      {
+        "signature": "int EnsureCapacity(int capacity)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.ensurecapacity",
+        "summary": "Ensures that the dictionary can hold up to a specified number of entries without any further expansion of its backing storage."
+      },
+      {
+        "signature": "void Add(TKey key, TValue value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.add",
+        "summary": "Adds the specified key and value to the dictionary."
+      },
+      {
+        "signature": "void Clear()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.clear",
+        "summary": "Removes all keys and values from the Dictionary."
+      },
+      {
+        "signature": "void OnDeserialization(object sender)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.ondeserialization",
+        "summary": "Implements the ISerializable interface and raises the deserialization event when the deserialization is complete."
+      },
+      {
+        "signature": "void TrimExcess()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trimexcess",
+        "summary": "Sets the capacity of this dictionary to what it would be if it had been originally initialized with all its entries."
+      },
+      {
+        "signature": "void TrimExcess(int capacity)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trimexcess",
+        "summary": "Sets the capacity of this dictionary to hold up a specified number of entries without any further expansion of its backing storage."
+      }
+    ]
+  },
+  "DynamicObject": {
+    "namespace": "System.Dynamic",
+    "name": "DynamicObject",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject",
+    "methods": [
+      {
+        "signature": "DynamicMetaObject GetMetaObject(Expression parameter)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.getmetaobject",
+        "summary": "Provides a DynamicMetaObject that dispatches to the dynamic virtual methods. The object can be encapsulated inside another DynamicMetaObject to provide custom behavior for individual actions. This method supports the Dynamic Language Runtime infrastructure for language implementers and it is not intended to be used directly from your code."
+      },
+      {
+        "signature": "IEnumerable<string> GetDynamicMemberNames()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.getdynamicmembernames",
+        "summary": "Returns the enumeration of all dynamic member names."
+      },
+      {
+        "signature": "bool TryBinaryOperation(BinaryOperationBinder binder, object arg, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trybinaryoperation",
+        "summary": "Provides implementation for binary operations. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations such as addition and multiplication."
+      },
+      {
+        "signature": "bool TryConvert(ConvertBinder binder, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.tryconvert",
+        "summary": "Provides implementation for type conversion operations. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations that convert an object from one type to another."
+      },
+      {
+        "signature": "bool TryCreateInstance(CreateInstanceBinder binder, object[] args, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trycreateinstance",
+        "summary": "Provides the implementation for operations that initialize a new instance of a dynamic object. This method is not intended for use in C# or Visual Basic."
+      },
+      {
+        "signature": "bool TryDeleteIndex(DeleteIndexBinder binder, object[] indexes)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trydeleteindex",
+        "summary": "Provides the implementation for operations that delete an object by index. This method is not intended for use in C# or Visual Basic."
+      },
+      {
+        "signature": "bool TryDeleteMember(DeleteMemberBinder binder)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trydeletemember",
+        "summary": "Provides the implementation for operations that delete an object member. This method is not intended for use in C# or Visual Basic."
+      },
+      {
+        "signature": "bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trygetindex",
+        "summary": "Provides the implementation for operations that get a value by index. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for indexing operations."
+      },
+      {
+        "signature": "bool TryGetMember(GetMemberBinder binder, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trygetmember",
+        "summary": "Provides the implementation for operations that get member values. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations such as getting a value for a property."
+      },
+      {
+        "signature": "bool TryInvoke(InvokeBinder binder, object[] args, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.tryinvoke",
+        "summary": "Provides the implementation for operations that invoke an object. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations such as invoking an object or a delegate."
+      },
+      {
+        "signature": "bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.tryinvokemember",
+        "summary": "Provides the implementation for operations that invoke a member. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations such as calling a method."
+      },
+      {
+        "signature": "bool TrySetIndex(SetIndexBinder binder, object[] indexes, object value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trysetindex",
+        "summary": "Provides the implementation for operations that set a value by index. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations that access objects by a specified index."
+      },
+      {
+        "signature": "bool TrySetMember(SetMemberBinder binder, object value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.trysetmember",
+        "summary": "Provides the implementation for operations that set member values. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations such as setting a value for a property."
+      },
+      {
+        "signature": "bool TryUnaryOperation(UnaryOperationBinder binder, out object result)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.tryunaryoperation",
+        "summary": "Provides implementation for unary operations. Classes derived from the DynamicObject class can override this method to specify dynamic behavior for operations such as negation, increment, or decrement."
+      }
+    ]
+  },
+  "Exception": {
+    "namespace": "System",
+    "name": "Exception",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception",
+    "properties": [
+      {
+        "signature": "Exception InnerException",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.innerexception",
+        "summary": "Gets the Exception instance that caused the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "IDictionary Data",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.data",
+        "summary": "Gets a collection of key/value pairs that provide additional user-defined information about the exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "MethodBase TargetSite",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.targetsite",
+        "summary": "Gets the method that throws the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int HResult",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.hresult",
+        "summary": "Gets or sets HRESULT, a coded numerical value that is assigned to a specific exception.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string HelpLink",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.helplink",
+        "summary": "Gets or sets a link to the help file associated with this exception.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string Message",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.message",
+        "summary": "Gets a message that describes the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "string Source",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.source",
+        "summary": "Gets or sets the name of the application or the object that causes the error.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string StackTrace",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.stacktrace",
+        "summary": "Gets a string representation of the immediate frames on the call stack.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "Exception GetBaseException()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.getbaseexception",
+        "summary": "When overridden in a derived class, returns the Exception that is the root cause of one or more subsequent exceptions."
+      },
+      {
+        "signature": "Type GetType()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.gettype",
+        "summary": "Gets the runtime type of the current instance."
+      },
+      {
+        "signature": "string ToString()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.tostring",
+        "summary": "Creates and returns a string representation of the current exception."
+      }
+    ]
+  },
+  "IOException": {
+    "namespace": "System.IO",
+    "name": "IOException",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.ioexception",
+    "properties": [
+      {
+        "signature": "Exception InnerException",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.innerexception",
+        "summary": "Gets the Exception instance that caused the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "IDictionary Data",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.data",
+        "summary": "Gets a collection of key/value pairs that provide additional user-defined information about the exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "MethodBase TargetSite",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.targetsite",
+        "summary": "Gets the method that throws the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int HResult",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.hresult",
+        "summary": "Gets or sets HRESULT, a coded numerical value that is assigned to a specific exception.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string HelpLink",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.helplink",
+        "summary": "Gets or sets a link to the help file associated with this exception.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string Message",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.message",
+        "summary": "Gets a message that describes the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "string Source",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.source",
+        "summary": "Gets or sets the name of the application or the object that causes the error.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string StackTrace",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.stacktrace",
+        "summary": "Gets a string representation of the immediate frames on the call stack.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "Exception GetBaseException()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.getbaseexception",
+        "summary": "When overridden in a derived class, returns the Exception that is the root cause of one or more subsequent exceptions."
+      },
+      {
+        "signature": "Type GetType()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.gettype",
+        "summary": "Gets the runtime type of the current instance."
+      },
+      {
+        "signature": "string ToString()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.tostring",
+        "summary": "Creates and returns a string representation of the current exception."
+      }
+    ]
+  },
+  "InvalidOperationException": {
+    "namespace": "System",
+    "name": "InvalidOperationException",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.invalidoperationexception",
+    "properties": [
+      {
+        "signature": "Exception InnerException",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.innerexception",
+        "summary": "Gets the Exception instance that caused the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "IDictionary Data",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.data",
+        "summary": "Gets a collection of key/value pairs that provide additional user-defined information about the exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "MethodBase TargetSite",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.targetsite",
+        "summary": "Gets the method that throws the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int HResult",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.hresult",
+        "summary": "Gets or sets HRESULT, a coded numerical value that is assigned to a specific exception.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string HelpLink",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.helplink",
+        "summary": "Gets or sets a link to the help file associated with this exception.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string Message",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.message",
+        "summary": "Gets a message that describes the current exception.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "string Source",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.source",
+        "summary": "Gets or sets the name of the application or the object that causes the error.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "string StackTrace",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.stacktrace",
+        "summary": "Gets a string representation of the immediate frames on the call stack.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "Exception GetBaseException()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.getbaseexception",
+        "summary": "When overridden in a derived class, returns the Exception that is the root cause of one or more subsequent exceptions."
+      },
+      {
+        "signature": "Type GetType()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.gettype",
+        "summary": "Gets the runtime type of the current instance."
+      },
+      {
+        "signature": "string ToString()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.exception.tostring",
+        "summary": "Creates and returns a string representation of the current exception."
+      }
+    ]
+  },
+  "List<T>": {
+    "namespace": "System.Collections.Generic",
+    "name": "List<T>",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1",
+    "properties": [
+      {
+        "signature": "T this[int index]",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.item",
+        "summary": "Gets or sets the element at the specified index."
+      },
+      {
+        "signature": "int Capacity",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.capacity",
+        "summary": "Gets or sets the total number of elements the internal data structure can hold without resizing.",
+        "property": [
+          "get",
+          "set"
+        ]
+      },
+      {
+        "signature": "int Count",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.count",
+        "summary": "Gets the number of elements contained in the List.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "Enumerator GetEnumerator()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.getenumerator",
+        "summary": "Returns an enumerator that iterates through the List."
+      },
+      {
+        "signature": "List<T> FindAll(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findall",
+        "summary": "Retrieves all the elements that match the conditions defined by the specified predicate."
+      },
+      {
+        "signature": "List<T> GetRange(int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.getrange",
+        "summary": "Creates a shallow copy of a range of elements in the source List."
+      },
+      {
+        "signature": "List<T> Slice(int start, int length)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.slice",
+        "summary": "Creates a shallow copy of a range of elements in the source List."
+      },
+      {
+        "signature": "List<TOutput> ConvertAll(Converter<T, TOutput> converter)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.convertall",
+        "summary": "Converts the elements in the current List to another type, and returns a list containing the converted elements."
+      },
+      {
+        "signature": "ReadOnlyCollection<T> AsReadOnly()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.asreadonly",
+        "summary": "Returns a read-only ReadOnlyCollection wrapper for the current collection."
+      },
+      {
+        "signature": "T Find(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.find",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the first occurrence within the entire List."
+      },
+      {
+        "signature": "T FindLast(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findlast",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the last occurrence within the entire List."
+      },
+      {
+        "signature": "T[] ToArray()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.toarray",
+        "summary": "Copies the elements of the List to a new array."
+      },
+      {
+        "signature": "bool Contains(T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.contains",
+        "summary": "Determines whether an element is in the List."
+      },
+      {
+        "signature": "bool Exists(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.exists",
+        "summary": "Determines whether the List contains elements that match the conditions defined by the specified predicate."
+      },
+      {
+        "signature": "bool Remove(T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.remove",
+        "summary": "Removes the first occurrence of a specific object from the List."
+      },
+      {
+        "signature": "bool TrueForAll(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.trueforall",
+        "summary": "Determines whether every element in the List matches the conditions defined by the specified predicate."
+      },
+      {
+        "signature": "int BinarySearch(T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.binarysearch",
+        "summary": "Searches the entire sorted List for an element using the default comparer and returns the zero-based index of the element."
+      },
+      {
+        "signature": "int BinarySearch(T item, IComparer<T> comparer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.binarysearch",
+        "summary": "Searches the entire sorted List for an element using the specified comparer and returns the zero-based index of the element."
+      },
+      {
+        "signature": "int BinarySearch(int index, int count, T item, IComparer<T> comparer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.binarysearch",
+        "summary": "Searches a range of elements in the sorted List for an element using the specified comparer and returns the zero-based index of the element."
+      },
+      {
+        "signature": "int EnsureCapacity(int capacity)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.ensurecapacity",
+        "summary": "Ensures that the capacity of this list is at least the specified capacity. If the current capacity is less than capacity, it is successively increased to twice the current capacity until it is at least the specified capacity."
+      },
+      {
+        "signature": "int FindIndex(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findindex",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the zero-based index of the first occurrence within the entire List."
+      },
+      {
+        "signature": "int FindIndex(int startIndex, Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findindex",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the zero-based index of the first occurrence within the range of elements in the List that extends from the specified index to the last element."
+      },
+      {
+        "signature": "int FindIndex(int startIndex, int count, Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findindex",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the zero-based index of the first occurrence within the range of elements in the List that starts at the specified index and contains the specified number of elements."
+      },
+      {
+        "signature": "int FindLastIndex(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findlastindex",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the zero-based index of the last occurrence within the entire List."
+      },
+      {
+        "signature": "int FindLastIndex(int startIndex, Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findlastindex",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the zero-based index of the last occurrence within the range of elements in the List that extends from the first element to the specified index."
+      },
+      {
+        "signature": "int FindLastIndex(int startIndex, int count, Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.findlastindex",
+        "summary": "Searches for an element that matches the conditions defined by the specified predicate, and returns the zero-based index of the last occurrence within the range of elements in the List that contains the specified number of elements and ends at the specified index."
+      },
+      {
+        "signature": "int IndexOf(T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.indexof",
+        "summary": "Searches for the specified object and returns the zero-based index of the first occurrence within the entire List."
+      },
+      {
+        "signature": "int IndexOf(T item, int index)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.indexof",
+        "summary": "Searches for the specified object and returns the zero-based index of the first occurrence within the range of elements in the List that extends from the specified index to the last element."
+      },
+      {
+        "signature": "int IndexOf(T item, int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.indexof",
+        "summary": "Searches for the specified object and returns the zero-based index of the first occurrence within the range of elements in the List that starts at the specified index and contains the specified number of elements."
+      },
+      {
+        "signature": "int LastIndexOf(T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.lastindexof",
+        "summary": "Searches for the specified object and returns the zero-based index of the last occurrence within the entire List."
+      },
+      {
+        "signature": "int LastIndexOf(T item, int index)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.lastindexof",
+        "summary": "Searches for the specified object and returns the zero-based index of the last occurrence within the range of elements in the List that extends from the first element to the specified index."
+      },
+      {
+        "signature": "int LastIndexOf(T item, int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.lastindexof",
+        "summary": "Searches for the specified object and returns the zero-based index of the last occurrence within the range of elements in the List that contains the specified number of elements and ends at the specified index."
+      },
+      {
+        "signature": "int RemoveAll(Predicate<T> match)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.removeall",
+        "summary": "Removes all the elements that match the conditions defined by the specified predicate."
+      },
+      {
+        "signature": "void Add(T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.add",
+        "summary": "Adds an object to the end of the List."
+      },
+      {
+        "signature": "void AddRange(IEnumerable<T> collection)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.addrange",
+        "summary": "Adds the elements of the specified collection to the end of the List."
+      },
+      {
+        "signature": "void Clear()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.clear",
+        "summary": "Removes all elements from the List."
+      },
+      {
+        "signature": "void CopyTo(T[] array)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.copyto",
+        "summary": "Copies the entire List to a compatible one-dimensional array, starting at the beginning of the target array."
+      },
+      {
+        "signature": "void CopyTo(T[] array, int arrayIndex)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.copyto",
+        "summary": "Copies the entire List to a compatible one-dimensional array, starting at the specified index of the target array."
+      },
+      {
+        "signature": "void CopyTo(int index, T[] array, int arrayIndex, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.copyto",
+        "summary": "Copies a range of elements from the List to a compatible one-dimensional array, starting at the specified index of the target array."
+      },
+      {
+        "signature": "void ForEach(Action<T> action)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.foreach",
+        "summary": "Performs the specified action on each element of the List."
+      },
+      {
+        "signature": "void Insert(int index, T item)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.insert",
+        "summary": "Inserts an element into the List at the specified index."
+      },
+      {
+        "signature": "void InsertRange(int index, IEnumerable<T> collection)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.insertrange",
+        "summary": "Inserts the elements of a collection into the List at the specified index."
+      },
+      {
+        "signature": "void RemoveAt(int index)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.removeat",
+        "summary": "Removes the element at the specified index of the List."
+      },
+      {
+        "signature": "void RemoveRange(int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.removerange",
+        "summary": "Removes a range of elements from the List."
+      },
+      {
+        "signature": "void Reverse()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.reverse",
+        "summary": "Reverses the order of the elements in the entire List."
+      },
+      {
+        "signature": "void Reverse(int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.reverse",
+        "summary": "Reverses the order of the elements in the specified range."
+      },
+      {
+        "signature": "void Sort()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort",
+        "summary": "Sorts the elements in the entire List using the default comparer."
+      },
+      {
+        "signature": "void Sort(Comparison<T> comparison)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort",
+        "summary": "Sorts the elements in the entire List using the specified Comparison."
+      },
+      {
+        "signature": "void Sort(IComparer<T> comparer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort",
+        "summary": "Sorts the elements in the entire List using the specified comparer."
+      },
+      {
+        "signature": "void Sort(int index, int count, IComparer<T> comparer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort",
+        "summary": "Sorts the elements in a range of elements in List using the specified comparer."
+      },
+      {
+        "signature": "void TrimExcess()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.trimexcess",
+        "summary": "Sets the capacity to the actual number of elements in the List, if that number is less than a threshold value."
+      }
+    ]
+  },
+  "SHA1": {
+    "namespace": "System.Security.Cryptography",
+    "name": "SHA1",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha1",
+    "properties": [
+      {
+        "signature": "bool CanReuseTransform",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.canreusetransform",
+        "summary": "Gets a value indicating whether the current transform can be reused.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "bool CanTransformMultipleBlocks",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.cantransformmultipleblocks",
+        "summary": "When overridden in a derived class, gets a value indicating whether multiple blocks can be transformed.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "byte[] Hash",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.hash",
+        "summary": "Gets the value of the computed hash code.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int HashSize",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.hashsize",
+        "summary": "Gets the size, in bits, of the computed hash code.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int InputBlockSize",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.inputblocksize",
+        "summary": "When overridden in a derived class, gets the input block size.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "int OutputBlockSize",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.outputblocksize",
+        "summary": "When overridden in a derived class, gets the output block size.",
+        "property": [
+          "get"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "Task<byte[]> ComputeHashAsync(Stream inputStream, CancellationToken cancellationToken)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.computehashasync",
+        "summary": "Asynchronously computes the hash value for the specified Stream object."
+      },
+      {
+        "signature": "bool TryComputeHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.trycomputehash",
+        "summary": "Attempts to compute the hash value for the specified byte array."
+      },
+      {
+        "signature": "bool TryHashFinal(Span<byte> destination, out int bytesWritten)",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.tryhashfinal",
+        "summary": "Attempts to finalize the hash computation after the last data is processed by the hash algorithm."
+      },
+      {
+        "signature": "byte[] ComputeHash(Stream inputStream)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.computehash",
+        "summary": "Computes the hash value for the specified Stream object."
+      },
+      {
+        "signature": "byte[] ComputeHash(byte[] buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.computehash",
+        "summary": "Computes the hash value for the specified byte array."
+      },
+      {
+        "signature": "byte[] ComputeHash(byte[] buffer, int offset, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.computehash",
+        "summary": "Computes the hash value for the specified region of the specified byte array."
+      },
+      {
+        "signature": "byte[] HashFinal()",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.hashfinal",
+        "summary": "When overridden in a derived class, finalizes the hash computation after the last data is processed by the cryptographic hash algorithm."
+      },
+      {
+        "signature": "byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.transformfinalblock",
+        "summary": "Computes the hash value for the specified region of the specified byte array."
+      },
+      {
+        "signature": "int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.transformblock",
+        "summary": "Computes the hash value for the specified region of the input byte array and copies the specified region of the input byte array to the specified region of the output byte array."
+      },
+      {
+        "signature": "void Clear()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.clear",
+        "summary": "Releases all resources used by the HashAlgorithm class."
+      },
+      {
+        "signature": "void Dispose()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.dispose",
+        "summary": "Releases all resources used by the current instance of the HashAlgorithm class."
+      },
+      {
+        "signature": "void Dispose(bool disposing)",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.dispose",
+        "summary": "Releases the unmanaged resources used by the HashAlgorithm and optionally releases the managed resources."
+      },
+      {
+        "signature": "void HashCore(ReadOnlySpan<byte> source)",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.hashcore",
+        "summary": "Routes data written to the object into the hash algorithm for computing the hash."
+      },
+      {
+        "signature": "void HashCore(byte[] array, int ibStart, int cbSize)",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.hashcore",
+        "summary": "When overridden in a derived class, routes data written to the object into the hash algorithm for computing the hash."
+      },
+      {
+        "signature": "void Initialize()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.initialize",
+        "summary": "Resets the hash algorithm to its initial state."
+      }
+    ],
+    "fields": [
+      {
+        "signature": "int HashSizeValue",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.hashsizevalue",
+        "summary": "Represents the size, in bits, of the computed hash code."
+      },
+      {
+        "signature": "int State",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.state",
+        "summary": "Represents the state of the hash computation."
+      }
+    ]
+  },
+  "TextWriter": {
+    "namespace": "System.IO",
+    "name": "TextWriter",
+    "dataType": "class",
+    "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter",
+    "properties": [
+      {
+        "signature": "Encoding Encoding",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.encoding",
+        "summary": "When overridden in a derived class, returns the character encoding in which the output is written.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "IFormatProvider FormatProvider",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.formatprovider",
+        "summary": "Gets an object that controls formatting.",
+        "property": [
+          "get"
+        ]
+      },
+      {
+        "signature": "string NewLine",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.newline",
+        "summary": "Gets or sets the line terminator string used by the current TextWriter.",
+        "property": [
+          "get",
+          "set"
+        ]
+      }
+    ],
+    "methods": [
+      {
+        "signature": "MarshalByRefObject MemberwiseClone(bool cloneIdentity)",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.marshalbyrefobject.memberwiseclone",
+        "summary": "Creates a shallow copy of the current MarshalByRefObject object."
+      },
+      {
+        "signature": "Task FlushAsync()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flushasync",
+        "summary": "Asynchronously clears all buffers for the current writer and causes any buffered data to be written to the underlying device."
+      },
+      {
+        "signature": "Task FlushAsync(CancellationToken cancellationToken)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flushasync",
+        "summary": "Asynchronously clears all buffers for the current writer and causes any buffered data to be written to the underlying device."
+      },
+      {
+        "signature": "Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync",
+        "summary": "Asynchronously writes a character memory region to the text stream."
+      },
+      {
+        "signature": "Task WriteAsync(StringBuilder value, CancellationToken cancellationToken)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync",
+        "summary": "Asynchronously writes a string builder to the text stream."
+      },
+      {
+        "signature": "Task WriteAsync(char value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync",
+        "summary": "Writes a character to the text stream asynchronously."
+      },
+      {
+        "signature": "Task WriteAsync(char[] buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync",
+        "summary": "Writes a character array to the text stream asynchronously."
+      },
+      {
+        "signature": "Task WriteAsync(char[] buffer, int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync",
+        "summary": "Writes a subarray of characters to the text stream asynchronously."
+      },
+      {
+        "signature": "Task WriteAsync(string value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync",
+        "summary": "Writes a string to the text stream asynchronously."
+      },
+      {
+        "signature": "Task WriteLineAsync()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes a line terminator to the text stream."
+      },
+      {
+        "signature": "Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes the text representation of a character memory region to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes the text representation of a string builder to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "Task WriteLineAsync(char value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes a character to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "Task WriteLineAsync(char[] buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes an array of characters to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "Task WriteLineAsync(char[] buffer, int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes a subarray of characters to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "Task WriteLineAsync(string value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync",
+        "summary": "Asynchronously writes a string to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "ValueTask DisposeAsync()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.disposeasync",
+        "summary": "Asynchronously releases all resources used by the TextWriter object."
+      },
+      {
+        "signature": "void Close()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.close",
+        "summary": "Closes the current writer and releases any system resources associated with the writer."
+      },
+      {
+        "signature": "void Dispose()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.dispose",
+        "summary": "Releases all resources used by the TextWriter object."
+      },
+      {
+        "signature": "void Dispose(bool disposing)",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.dispose",
+        "summary": "Releases the unmanaged resources used by the TextWriter and optionally releases the managed resources."
+      },
+      {
+        "signature": "void Flush()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flush",
+        "summary": "Clears all buffers for the current writer and causes any buffered data to be written to the underlying device."
+      },
+      {
+        "signature": "void Write(ReadOnlySpan<char> buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a character span to the text stream."
+      },
+      {
+        "signature": "void Write(StringBuilder value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a string builder to the text stream."
+      },
+      {
+        "signature": "void Write(bool value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of a Boolean value to the text stream."
+      },
+      {
+        "signature": "void Write(char value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a character to the text stream."
+      },
+      {
+        "signature": "void Write(char[] buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a character array to the text stream."
+      },
+      {
+        "signature": "void Write(char[] buffer, int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a subarray of characters to the text stream."
+      },
+      {
+        "signature": "void Write(decimal value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of a decimal value to the text stream."
+      },
+      {
+        "signature": "void Write(double value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of an 8-byte floating-point value to the text stream."
+      },
+      {
+        "signature": "void Write(float value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of a 4-byte floating-point value to the text stream."
+      },
+      {
+        "signature": "void Write(int value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of a 4-byte signed integer to the text stream."
+      },
+      {
+        "signature": "void Write(long value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of an 8-byte signed integer to the text stream."
+      },
+      {
+        "signature": "void Write(object value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of an object to the text stream by calling the ToString method on that object."
+      },
+      {
+        "signature": "void Write(string format, object arg0)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a formatted string to the text stream, using the same semantics as the Format method."
+      },
+      {
+        "signature": "void Write(string format, object arg0, object arg1)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a formatted string to the text stream using the same semantics as the Format method."
+      },
+      {
+        "signature": "void Write(string format, object arg0, object arg1, object arg2)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a formatted string to the text stream, using the same semantics as the Format method."
+      },
+      {
+        "signature": "void Write(string format, params object[] arg)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a formatted string to the text stream, using the same semantics as the Format method."
+      },
+      {
+        "signature": "void Write(string value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes a string to the text stream."
+      },
+      {
+        "signature": "void Write(uint value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of a 4-byte unsigned integer to the text stream."
+      },
+      {
+        "signature": "void Write(ulong value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write",
+        "summary": "Writes the text representation of an 8-byte unsigned integer to the text stream."
+      },
+      {
+        "signature": "void WriteLine()",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes a line terminator to the text stream."
+      },
+      {
+        "signature": "void WriteLine(ReadOnlySpan<char> buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a character span to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(StringBuilder value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a string builder to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(bool value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a Boolean value to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(char value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes a character to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(char[] buffer)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes an array of characters to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(char[] buffer, int index, int count)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes a subarray of characters to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(decimal value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a decimal value to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(double value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a 8-byte floating-point value to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(float value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a 4-byte floating-point value to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(int value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a 4-byte signed integer to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(long value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of an 8-byte signed integer to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(object value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of an object to the text stream, by calling the ToString method on that object, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(string format, object arg0)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes a formatted string and a new line to the text stream, using the same semantics as the Format method."
+      },
+      {
+        "signature": "void WriteLine(string format, object arg0, object arg1)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes a formatted string and a new line to the text stream, using the same semantics as the Format method."
+      },
+      {
+        "signature": "void WriteLine(string format, object arg0, object arg1, object arg2)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes out a formatted string and a new line to the text stream, using the same semantics as Format."
+      },
+      {
+        "signature": "void WriteLine(string format, params object[] arg)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes out a formatted string and a new line to the text stream, using the same semantics as Format."
+      },
+      {
+        "signature": "void WriteLine(string value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes a string to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(uint value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of a 4-byte unsigned integer to the text stream, followed by a line terminator."
+      },
+      {
+        "signature": "void WriteLine(ulong value)",
+        "modifiers": [
+          "public"
+        ],
+        "protected": false,
+        "virtual": true,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline",
+        "summary": "Writes the text representation of an 8-byte unsigned integer to the text stream, followed by a line terminator."
+      }
+    ],
+    "fields": [
+      {
+        "signature": "char[] CoreNewLine",
+        "modifiers": [
+          "protected"
+        ],
+        "protected": true,
+        "virtual": false,
+        "docsUrl": "https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.corenewline",
+        "summary": "Stores the newline characters used for this TextWriter."
+      }
+    ]
+  }
+}

--- a/webapp/src/pages/DataTypePage.vue
+++ b/webapp/src/pages/DataTypePage.vue
@@ -135,6 +135,18 @@ function memberTo(section, member) {
   if (section.type === 'values') return undefined
   return props.baseUrl + member.path + signatureHash(member.signature)
 }
+// Inherited BCL members (WWW-3489) link off-site to MS Learn; everything else is
+// an internal RouterLink (values are plain, non-clickable rows).
+function memberComponent(section, member) {
+  if (section.type === 'values') return 'div'
+  if (member.externalUrl) return 'a'
+  return RouterLink
+}
+function memberBindings(section, member) {
+  if (section.type === 'values') return {}
+  if (member.externalUrl) return { href: member.externalUrl, target: '_blank', rel: 'noopener' }
+  return { to: memberTo(section, member) }
+}
 function isInherited(member) {
   return member.parent !== namespace.value + '.' + name.value
 }
@@ -177,9 +189,20 @@ watch(memberSections, computeOpen)
     <p v-if="inheritance.length" class="italic">
       <span>Inheritence: </span>
       <template v-for="(item, index) in inheritance" :key="item.name">
-        <RouterLink v-if="item.link" class="routerlink" :to="baseUrl + item.link.toLowerCase()">{{
-          item.name
-        }}</RouterLink>
+        <a
+          v-if="item.external"
+          :href="item.external"
+          target="_blank"
+          rel="noopener"
+          class="routerlink"
+          >{{ item.name }}</a
+        >
+        <RouterLink
+          v-else-if="item.link"
+          class="routerlink"
+          :to="baseUrl + item.link.toLowerCase()"
+          >{{ item.name }}</RouterLink
+        >
         <span v-else>{{ item.name }}</span>
         <Icon name="arrow-forward" class="inline align-middle" />
         <span v-if="index === inheritance.length - 1">{{ name }}</span>
@@ -246,10 +269,10 @@ watch(memberSections, computeOpen)
         </AccordionHeader>
         <AccordionContent class="pl-4">
           <component
-            :is="section.type === 'values' ? 'div' : RouterLink"
+            :is="memberComponent(section, member)"
             v-for="(member, i) in section.items.filter(filterFunc)"
             :key="i"
-            :to="memberTo(section, member)"
+            v-bind="memberBindings(section, member)"
             class="flex flex-col gap-1 border-b border-neutral-100 px-2 py-2 md:flex-row dark:border-neutral-800"
             :class="memberClass(member)"
           >

--- a/webapp/src/utils/bcl.js
+++ b/webapp/src/utils/bcl.js
@@ -1,0 +1,26 @@
+// Loader for generated .NET Base Class Library (BCL) base-type metadata (WWW-3489).
+//
+// The generator (api_docify) is purely syntactic: it records a class's base type as
+// a raw string (e.g. "Dictionary<object, object>") but has no member data for types
+// outside the parsed RhinoCommon source. So a RhinoCommon class deriving from a BCL
+// type used to show none of its inherited API — RuntimeDocumentDataTable looked like
+// it had 3 members instead of ~20, hiding the fact that it IS a Dictionary.
+//
+// bcl_api.json is produced by the C# generator (src/Parse/BclMetadata.cs) reflecting
+// the real .NET reference assemblies + their XML docs via Roslyn — it is NOT hand-
+// written, so signatures/summaries stay authoritative and never drift. It is keyed by
+// the same normalized base token getInheritance() computes (last dotted segment with
+// generic args collapsed to "<T>", e.g. "Dictionary<T>", "IOException"). Each entry is
+// shaped like a parsed type (namespace/name/docsUrl + member arrays) with a per-member
+// docsUrl pointing at Microsoft Learn.
+//
+// Regenerate after a data refresh with:
+//   dotnet run --project src -- bcl webapp/src/api_info.json webapp/src/bcl_api.json
+import bclData from '@/bcl_api.json'
+
+// Resolve a normalized base token to a synthetic BCL type node, or null.
+export function lookupBcl(normalizedBase) {
+  return Object.prototype.hasOwnProperty.call(bclData, normalizedBase)
+    ? bclData[normalizedBase]
+    : null
+}

--- a/webapp/src/utils/members.js
+++ b/webapp/src/utils/members.js
@@ -28,6 +28,8 @@ export function collectMembers(node, memberType, typeMap, includeInherited = tru
       const inherited = inheritedList.map((m) => {
         const clone = { ...m, parent, namespace: entry.item.namespace, inherited: true }
         clone.path = memberUrl(memberType, clone)
+        // BCL members (WWW-3489) have no local page — link out to MS Learn.
+        if (entry.external) clone.externalUrl = m.docsUrl || entry.external
         return clone
       })
       members = members.concat(inherited)

--- a/webapp/src/utils/tree.js
+++ b/webapp/src/utils/tree.js
@@ -53,7 +53,11 @@ export function buildMemberGroups(type, typeMap) {
   for (const childType of GROUP_ORDER) {
     const lc = childType.toLowerCase()
     const includeInherited = lc !== 'constructors'
-    const members = collectMembers(type, lc, typeMap, includeInherited)
+    // External (BCL) inherited members link off-site, so they don't belong in the
+    // in-site navigation tree — they're still listed on the type page (WWW-3489).
+    const members = collectMembers(type, lc, typeMap, includeInherited).filter(
+      (m) => !m.externalUrl
+    )
     if (!members || members.length < 1) continue
 
     const seen = []

--- a/webapp/src/utils/typemap.js
+++ b/webapp/src/utils/typemap.js
@@ -1,4 +1,5 @@
 // Type index + inheritance helpers. Pure — ported from ViewModel.js.
+import { lookupBcl } from './bcl.js'
 
 // name -> type. Rhino.Geometry takes precedence on name clashes (RH-80781).
 export function buildTypeMap(apiInfo) {
@@ -28,11 +29,22 @@ export function getInheritance(item, typeMap) {
     if (index > 0) baseclass = baseclass.substring(0, index + 1) + 'T>'
     const link = item.baseclass.toLowerCase()
     const node = { name: item.baseclass }
-    item = typeMap[baseclass]
-    if (baseclass === 'EventArgs') item = null
-    if (item) {
+    const next = typeMap[baseclass]
+    if (baseclass === 'EventArgs') {
+      item = null
+    } else if (next) {
       node.link = link
-      node.item = item
+      node.item = next
+      item = next
+    } else {
+      // Base type isn't a parsed RhinoCommon type — try the generated BCL metadata
+      // (WWW-3489) so the chain links out and inherited members can be listed.
+      const bcl = lookupBcl(baseclass)
+      if (bcl) {
+        node.item = bcl
+        node.external = bcl.docsUrl
+      }
+      item = null // BCL bases don't chain further here
     }
     rc.push(node)
   }

--- a/webapp/test/integration.test.js
+++ b/webapp/test/integration.test.js
@@ -56,6 +56,34 @@ describe('real-data pipeline', () => {
     }
   })
 
+  it('surfaces BCL-inherited members (WWW-3489: RuntimeDocumentDataTable is a Dictionary)', () => {
+    const rd = pathMap['rhino.docobjects.tables.runtimedocumentdatatable']
+    expect(rd).toBeTruthy()
+    expect(rd.baseclass).toBe('Dictionary<object, object>')
+
+    // Inheritance chain now includes the BCL base, linked out to MS Learn.
+    const chain = getInheritance(rd, typeMap)
+    const dictNode = chain.find((n) => n.name.startsWith('Dictionary'))
+    expect(dictNode).toBeTruthy()
+    expect(dictNode.external).toMatch(/learn\.microsoft\.com/)
+
+    // Inherited Dictionary members appear alongside the type's own members.
+    const methods = collectMembers(rd, 'methods', typeMap, true)
+    const sigs = methods.map((m) => m.signature)
+    expect(sigs).toContain('bool ContainsKey(TKey key)')
+    expect(sigs).toContain('bool Remove(TKey key)')
+    const own = methods.find((m) => m.signature.includes('GetValue'))
+    expect(own.inherited).toBeUndefined() // the type's own member, unaffected
+    const inheritedCount = methods.filter((m) => m.externalUrl).length
+    expect(inheritedCount).toBeGreaterThan(4)
+
+    // ...but external BCL members stay OUT of the in-site nav tree.
+    const groups = buildMemberGroups(rd, typeMap)
+    const treeMethods = groups.find((g) => g.label === 'Methods')
+    const treeLabels = treeMethods ? treeMethods.children.map((c) => c.label) : []
+    expect(treeLabels.some((l) => l.startsWith('ContainsKey'))).toBe(false)
+  })
+
   it('search list flattens types + members', () => {
     const list = buildSearchList(info)
     expect(list.length).toBeGreaterThan(5000)

--- a/webapp/test/render.test.js
+++ b/webapp/test/render.test.js
@@ -78,6 +78,32 @@ describe('app renders and navigates (happy-dom mount)', () => {
     expect(wrapper.html().length).toBeGreaterThan(500)
   })
 
+  // WWW-3489: a type deriving from a BCL base (Dictionary) must render the base in
+  // the inheritance chain AND list its inherited members, all linked to MS Learn.
+  it('renders BCL-inherited members as external links', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({ history: createMemoryHistory('/'), routes })
+    const wrapper = mount(App, { global: { plugins: [pinia, router] } })
+    await router.push('/')
+    await router.isReady()
+    await settle()
+
+    await router.push('/rhino.docobjects.tables.runtimedocumentdatatable')
+    await settle()
+
+    expect(wrapper.text()).toContain('RuntimeDocumentDataTable class')
+    // inherited Dictionary members are listed on the page...
+    expect(wrapper.text()).toContain('ContainsKey')
+    // ...and both the chain base and the member rows link out to MS Learn.
+    const msLinks = wrapper
+      .findAll('a')
+      .map((a) => a.attributes('href') || '')
+      .filter((h) => h.includes('learn.microsoft.com'))
+    expect(msLinks.some((h) => h.includes('system.collections.generic.dictionary-2'))).toBe(true)
+    expect(msLinks.some((h) => h.endsWith('dictionary-2.containskey'))).toBe(true)
+  })
+
   it('highlights the specific overload node (not just the parent)', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)

--- a/webapp/test/utils.test.js
+++ b/webapp/test/utils.test.js
@@ -5,6 +5,7 @@ import { itemPath, memberUrl } from '@/utils/paths.js'
 import { refToPath } from '@/utils/sandcastle.js'
 import { buildTypeMap, getInheritance } from '@/utils/typemap.js'
 import { collectMembers } from '@/utils/members.js'
+import { lookupBcl } from '@/utils/bcl.js'
 
 describe('version.sinceIsGreater', () => {
   it('strictly greater', () => {
@@ -131,5 +132,77 @@ describe('members.collectMembers does not mutate source', () => {
   })
   it('inheritance chain resolves', () => {
     expect(getInheritance(raw[1], typeMap).map((n) => n.name)).toEqual(['NS.Base'])
+  })
+})
+
+describe('BCL base types (WWW-3489)', () => {
+  it('lookupBcl resolves known bases, null otherwise', () => {
+    expect(lookupBcl('NotABclType')).toBeNull()
+    const dict = lookupBcl('Dictionary<T>')
+    expect(dict.namespace).toBe('System.Collections.Generic')
+    expect(dict.docsUrl).toContain('system.collections.generic.dictionary-2')
+    // members carry their own MS Learn page URL
+    const containsKey = dict.methods.find((m) => m.signature.startsWith('bool ContainsKey'))
+    expect(containsKey.docsUrl).toMatch(/dictionary-2\.containskey$/)
+    const indexer = dict.properties.find((p) => p.signature.includes('this['))
+    expect(indexer.docsUrl).toMatch(/dictionary-2\.item$/)
+  })
+
+  it('getInheritance links a BCL base externally (Dictionary)', () => {
+    const raw = [
+      {
+        namespace: 'NS',
+        name: 'RuntimeTable',
+        dataType: 'class',
+        baseclass: 'Dictionary<object, object>',
+        methods: [{ signature: 'void Own()' }],
+      },
+    ]
+    const chain = getInheritance(raw[0], buildTypeMap(raw))
+    expect(chain).toHaveLength(1)
+    // chain shows the original closed-generic name but links out to MS Learn
+    expect(chain[0].name).toBe('Dictionary<object, object>')
+    expect(chain[0].external).toMatch(/^https:\/\/learn\.microsoft\.com/)
+    expect(chain[0].item).toBeTruthy()
+    expect(chain[0].link).toBeUndefined() // not an internal route
+  })
+
+  it('collectMembers lists inherited BCL members with external links (no mutation)', () => {
+    const raw = [
+      {
+        namespace: 'Rhino.DocObjects.Tables',
+        name: 'RuntimeDocumentDataTable',
+        dataType: 'class',
+        baseclass: 'Dictionary<object, object>',
+        methods: [{ signature: 'void Own()' }],
+      },
+    ]
+    const methods = collectMembers(raw[0], 'methods', buildTypeMap(raw), true)
+    const containsKey = methods.find((m) => m.signature.startsWith('bool ContainsKey'))
+    expect(containsKey).toBeTruthy()
+    expect(containsKey.inherited).toBe(true)
+    expect(containsKey.externalUrl).toMatch(/dictionary-2\.containskey$/)
+    expect(containsKey.parent).toBe('System.Collections.Generic.Dictionary<TKey, TValue>')
+    // own member is not flagged inherited and has no external link
+    const own = methods.find((m) => m.signature === 'void Own()')
+    expect(own.inherited).toBeUndefined()
+    expect(own.externalUrl).toBeUndefined()
+    // the shared registry member object must not be mutated by collection
+    expect(lookupBcl('Dictionary<T>').methods[0].inherited).toBeUndefined()
+    expect(lookupBcl('Dictionary<T>').methods[0].parent).toBeUndefined()
+  })
+
+  it('skips inherited BCL members when includeInherited is false', () => {
+    const raw = [
+      {
+        namespace: 'NS',
+        name: 'T',
+        dataType: 'class',
+        baseclass: 'List<Thing>',
+        methods: [{ signature: 'void Own()' }],
+      },
+    ]
+    const methods = collectMembers(raw[0], 'methods', buildTypeMap(raw), false)
+    expect(methods.map((m) => m.signature)).toEqual(['void Own()'])
   })
 })


### PR DESCRIPTION
Types deriving from BCL bases (e.g. RuntimeDocumentDataTable : Dictionary) showed none of their inherited API. Generator now reflects .NET reference assemblies + XML docs via Roslyn -> bcl_api.json; webapp renders these as inherited members + inheritance chain linking to MS Learn.

- src/Parse/BclMetadata.cs: Roslyn extractor; `bcl` subcommand + auto-run in build
- webapp typemap/members/tree: resolve BCL bases, keep external members out of nav tree
- webapp DataTypePage: external <a> for chain + member rows
- webapp/src/bcl_api.json: generated (Dictionary/List/Exception/Attribute/...)